### PR TITLE
Occupation Diversity fix

### DIFF
--- a/lib/eqlink/analytics/core.py
+++ b/lib/eqlink/analytics/core.py
@@ -476,7 +476,7 @@ class CoreAnalytics:
         soc_code: str = "00-0000",
         soc_type: int = 0,
         demographic_catagory: str = "A",
-        occ_level: str = "6",
+        occ_level: str = "7",
         as_frame: bool = False,
     ) -> Union[Any, pd.DataFrame]:
         """Runs the Occupation Diversity Analytic.

--- a/lib/eqlink/utilities/parsers.py
+++ b/lib/eqlink/utilities/parsers.py
@@ -23,8 +23,10 @@ class Parse:
                 elif type(value) is dict:
                     if "displayText" in value:
                         row_values.append(value["displayText"])
+                    elif "displayValue" in value:                        
+                        row_values.append(value["displayValue"])
                     elif "code" in value:
-                        row_values.append(value["code"])
+                        row_values.append(value["code"])                                        
                     else:
                         raise ValueError
             table.append(row_values)
@@ -63,7 +65,15 @@ class Parse:
                     elif "code" in value:
                         row_values.append(value["code"])
                     else:
-                        raise ValueError
+                        def parse_nested_dict(d):
+                            if "displayText" in d:
+                                return d["displayText"]
+                            elif "code" in d:
+                                return d["code"]
+                            else:
+                                return {k: parse_nested_dict(v) if isinstance(v, dict) else v for k, v in d.items()}
+
+                        row_values.append(parse_nested_dict(value))
             table.append(row_values)
 
         dict_table = {}

--- a/test/test_analytics/test_core.py
+++ b/test/test_analytics/test_core.py
@@ -123,6 +123,16 @@ class TestShiftShare:
 
         assert type(datadict) == dict
 
+class TestOccupationDiversity:
+    def test_1(self):
+        cnxn.core.occupation_diversity(as_frame=True)
+
+        return
+    def test_T(self):
+        cnxn.core.occupation_diversity(as_frame=True, demographic_category="T")
+
+        return
+    
 
 class TestIndustryDiversity:
     def test_1(self):


### PR DESCRIPTION
- Change occ diversity default occ level to 7
- Handle `displayValue` return type in parser, fixing the error in occ diversity "T" table.